### PR TITLE
Move jsfeat up a level in CommonJS packaging

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name" : "jsfeat",
-    "version" : "0.0.1",
+    "version" : "0.0.2",
     "description" : "JavaScript Computer Vision library",
     "author" : "Eugene Zatepyakin (http://www.inspirit.ru/)",
     "files" : "build/jsfeat.js",

--- a/src/jsfeat_export.js
+++ b/src/jsfeat_export.js
@@ -1,20 +1,15 @@
 /**
  * @author Eugene Zatepyakin / http://inspirit.ru/
  */
- 
+
 (function(lib) {
     "use strict";
 
-    var shim = {};
-    if (typeof(exports) === 'undefined') {
+    if (!module || !module.exports) {
         // in a browser, define its namespaces in global
-        shim.exports = window;
-    } else {    
-        // in commonjs, define its namespaces in exports
-        shim.exports = exports;
-    }
-
-    if(typeof(shim.exports) !== 'undefined') {
-        shim.exports.jsfeat = lib;
+        window.jsfeat = lib;
+    } else {
+        // in commonjs, or when AMD wrapping has been applied, define its namespaces as exports
+        module.exports = lib;
     }
 })(jsfeat);


### PR DESCRIPTION
This way it can be require'd like:

var jsfeat = require('jsfeat');

Rather than:

var jsfeat = require('jsfeat').jsfeat;

Btw, just want to rehash that it's probably best for you to own the module on NPM. If you tell me a user, I'll make them the owner.

Deploying new stuff to NPM is just:
- Update the version number in your package.json.
- `npm publish` (NPM comes with Node, so you need that installed.

Cheers!
