### PR TITLE
Added main to bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,6 +4,7 @@
     "version" : "0.0.8",
     "description" : "JavaScript Computer Vision library",
     "author" : "Eugene Zatepyakin (http://www.inspirit.ru/)",
+    "main" : "build/jsfeat-min.js",
 
     "ignore": [
       "src",


### PR DESCRIPTION
To use tools like [wiredep](https://github.com/taptapship/wiredep) we need a main in the bower.json file. This allows for the automatic addition of the jsfeat-min.js file our source code.