### PR TITLE
fix: declare all variables in Hough Transform

### DIFF
--- a/src/jsfeat_imgproc.js
+++ b/src/jsfeat_imgproc.js
@@ -628,12 +628,12 @@
                 var height = img.rows;
                 var step = width;
 
-                min_theta = 0.0;
-                max_theta = Math.PI;
+                var min_theta = 0.0;
+                var max_theta = Math.PI;
 
-                numangle = Math.round((max_theta - min_theta) / theta_res);
-                numrho = Math.round(((width + height) * 2 + 1) / rho_res);
-                irho = 1.0 / rho_res;
+                var numangle = Math.round((max_theta - min_theta) / theta_res);
+                var numrho = Math.round(((width + height) * 2 + 1) / rho_res);
+                var irho = 1.0 / rho_res;
 
                 var accum = new Int32Array((numangle+2) * (numrho+2)); //typed arrays are initialized to 0
                 var tabSin = new Float32Array(numangle);
@@ -663,7 +663,7 @@
 
                 // stage 2. find local maximums
                 //TODO: Consider making a vector class that uses typed arrays
-                _sort_buf = new Array();
+                var _sort_buf = new Array();
                 for(var r = 0; r < numrho; r++ ) {
                     for(var n = 0; n < numangle; n++ ) {
                         var base = (n+1) * (numrho+2) + r+1;
@@ -681,9 +681,9 @@
                 });
 
                 // stage 4. store the first min(total,linesMax) lines to the output buffer
-                linesMax = Math.min(numangle*numrho, _sort_buf.length);
-                scale = 1.0 / (numrho+2);
-                lines = new Array();
+                var linesMax = Math.min(numangle*numrho, _sort_buf.length);
+                var scale = 1.0 / (numrho+2);
+                var lines = new Array();
                 for( var i = 0; i < linesMax; i++ ) {
                     var idx = _sort_buf[i];
                     var n = Math.floor(idx*scale) - 1;


### PR DESCRIPTION
Some variables in the `hough_transform` function were not declared.