### PR TITLE
fix: set srcObject to the MediaStream directly for latest browsers

### DIFF
--- a/sample_boxblur.html
+++ b/sample_boxblur.html
@@ -71,10 +71,14 @@
                 video.addEventListener('loadeddata', readyListener);
 
                 compatibility.getUserMedia({video: true}, function(stream) {
-                    try {
-                        video.src = compatibility.URL.createObjectURL(stream);
-                    } catch (error) {
-                        video.src = stream;
+                    if(video.srcObject !== undefined){
+                        video.srcObject = stream
+                    } else {
+                        try {
+                            video.src = compatibility.URL.createObjectURL(stream);
+                        } catch (error) {
+                            video.src = stream;
+                        }
                     }
                     setTimeout(function() {
                             video.play();

--- a/sample_canny_edge.html
+++ b/sample_canny_edge.html
@@ -70,10 +70,14 @@
                 video.addEventListener('loadeddata', readyListener);
 
                 compatibility.getUserMedia({video: true}, function(stream) {
-                    try {
-                        video.src = compatibility.URL.createObjectURL(stream);
-                    } catch (error) {
-                        video.src = stream;
+                    if(video.srcObject !== undefined){
+                        video.srcObject = stream
+                    } else {
+                        try {
+                            video.src = compatibility.URL.createObjectURL(stream);
+                        } catch (error) {
+                            video.src = stream;
+                        }
                     }
                     setTimeout(function() {
                             video.play();

--- a/sample_equalize_hist.html
+++ b/sample_equalize_hist.html
@@ -69,10 +69,14 @@
                 video.addEventListener('loadeddata', readyListener);
 
                 compatibility.getUserMedia({video: true}, function(stream) {
-                    try {
-                        video.src = compatibility.URL.createObjectURL(stream);
-                    } catch (error) {
-                        video.src = stream;
+                    if(video.srcObject !== undefined){
+                        video.srcObject = stream
+                    } else {
+                        try {
+                            video.src = compatibility.URL.createObjectURL(stream);
+                        } catch (error) {
+                            video.src = stream;
+                        }
                     }
                     setTimeout(function() {
                             video.play();

--- a/sample_fast_corners.html
+++ b/sample_fast_corners.html
@@ -70,10 +70,14 @@
                 video.addEventListener('loadeddata', readyListener);
 
                 compatibility.getUserMedia({video: true}, function(stream) {
-                    try {
-                        video.src = compatibility.URL.createObjectURL(stream);
-                    } catch (error) {
-                        video.src = stream;
+                    if(video.srcObject !== undefined){
+                        video.srcObject = stream
+                    } else {
+                        try {
+                            video.src = compatibility.URL.createObjectURL(stream);
+                        } catch (error) {
+                            video.src = stream;
+                        }
                     }
                     setTimeout(function() {
                             video.play();

--- a/sample_gaussblur.html
+++ b/sample_gaussblur.html
@@ -70,10 +70,14 @@
                 video.addEventListener('loadeddata', readyListener);
 
                 compatibility.getUserMedia({video: true}, function(stream) {
-                    try {
-                        video.src = compatibility.URL.createObjectURL(stream);
-                    } catch (error) {
-                        video.src = stream;
+                    if(video.srcObject !== undefined){
+                        video.srcObject = stream
+                    } else {
+                        try {
+                            video.src = compatibility.URL.createObjectURL(stream);
+                        } catch (error) {
+                            video.src = stream;
+                        }
                     }
                     setTimeout(function() {
                             video.play();

--- a/sample_grayscale.html
+++ b/sample_grayscale.html
@@ -70,10 +70,14 @@
                 video.addEventListener('loadeddata', readyListener);
 
                 compatibility.getUserMedia({video: true}, function(stream) {
-                    try {
-                        video.src = compatibility.URL.createObjectURL(stream);
-                    } catch (error) {
-                        video.src = stream;
+                    if(video.srcObject !== undefined){
+                        video.srcObject = stream
+                    } else {
+                        try {
+                            video.src = compatibility.URL.createObjectURL(stream);
+                        } catch (error) {
+                            video.src = stream;
+                        }
                     }
                     setTimeout(function() {
                             video.play();

--- a/sample_haar_face.html
+++ b/sample_haar_face.html
@@ -71,10 +71,14 @@
                 video.addEventListener('loadeddata', readyListener);
 
                 compatibility.getUserMedia({video: true}, function(stream) {
-                    try {
-                        video.src = compatibility.URL.createObjectURL(stream);
-                    } catch (error) {
-                        video.src = stream;
+                    if(video.srcObject !== undefined){
+                        video.srcObject = stream
+                    } else {
+                        try {
+                            video.src = compatibility.URL.createObjectURL(stream);
+                        } catch (error) {
+                            video.src = stream;
+                        }
                     }
                     setTimeout(function() {
                             video.play();

--- a/sample_oflow_lk.html
+++ b/sample_oflow_lk.html
@@ -70,10 +70,14 @@
                 video.addEventListener('loadeddata', readyListener);
 
                 compatibility.getUserMedia({video: true}, function(stream) {
-                    try {
-                        video.src = compatibility.URL.createObjectURL(stream);
-                    } catch (error) {
-                        video.src = stream;
+                    if(video.srcObject !== undefined){
+                        video.srcObject = stream
+                    } else {
+                        try {
+                            video.src = compatibility.URL.createObjectURL(stream);
+                        } catch (error) {
+                            video.src = stream;
+                        }
                     }
                     setTimeout(function() {
                             video.play();

--- a/sample_orb.html
+++ b/sample_orb.html
@@ -70,10 +70,14 @@
                 video.addEventListener('loadeddata', readyListener);
 
                 compatibility.getUserMedia({video: true}, function(stream) {
-                    try {
-                        video.src = compatibility.URL.createObjectURL(stream);
-                    } catch (error) {
-                        video.src = stream;
+                    if(video.srcObject !== undefined){
+                        video.srcObject = stream
+                    } else {
+                        try {
+                            video.src = compatibility.URL.createObjectURL(stream);
+                        } catch (error) {
+                            video.src = stream;
+                        }
                     }
                     setTimeout(function() {
                             video.play();

--- a/sample_pyrdown.html
+++ b/sample_pyrdown.html
@@ -69,10 +69,14 @@
                 video.addEventListener('loadeddata', readyListener);
 
                 compatibility.getUserMedia({video: true}, function(stream) {
-                    try {
-                        video.src = compatibility.URL.createObjectURL(stream);
-                    } catch (error) {
-                        video.src = stream;
+                    if(video.srcObject !== undefined){
+                        video.srcObject = stream
+                    } else {
+                        try {
+                            video.src = compatibility.URL.createObjectURL(stream);
+                        } catch (error) {
+                            video.src = stream;
+                        }
                     }
                     setTimeout(function() {
                             video.play();

--- a/sample_scharr.html
+++ b/sample_scharr.html
@@ -70,10 +70,14 @@
                 video.addEventListener('loadeddata', readyListener);
 
                 compatibility.getUserMedia({video: true}, function(stream) {
-                    try {
-                        video.src = compatibility.URL.createObjectURL(stream);
-                    } catch (error) {
-                        video.src = stream;
+                    if(video.srcObject !== undefined){
+                        video.srcObject = stream
+                    } else {
+                        try {
+                            video.src = compatibility.URL.createObjectURL(stream);
+                        } catch (error) {
+                            video.src = stream;
+                        }
                     }
                     setTimeout(function() {
                             video.play();

--- a/sample_sobel.html
+++ b/sample_sobel.html
@@ -70,10 +70,14 @@
                 video.addEventListener('loadeddata', readyListener);
 
                 compatibility.getUserMedia({video: true}, function(stream) {
-                    try {
-                        video.src = compatibility.URL.createObjectURL(stream);
-                    } catch (error) {
-                        video.src = stream;
+                    if(video.srcObject !== undefined){
+                        video.srcObject = stream
+                    } else {
+                        try {
+                            video.src = compatibility.URL.createObjectURL(stream);
+                        } catch (error) {
+                            video.src = stream;
+                        }
                     }
                     setTimeout(function() {
                             video.play();

--- a/sample_sobel_edge.html
+++ b/sample_sobel_edge.html
@@ -70,10 +70,14 @@
                 video.addEventListener('loadeddata', readyListener);
 
                 compatibility.getUserMedia({video: true}, function(stream) {
-                    try {
-                        video.src = compatibility.URL.createObjectURL(stream);
-                    } catch (error) {
-                        video.src = stream;
+                    if(video.srcObject !== undefined){
+                        video.srcObject = stream
+                    } else {
+                        try {
+                            video.src = compatibility.URL.createObjectURL(stream);
+                        } catch (error) {
+                            video.src = stream;
+                        }
                     }
                     setTimeout(function() {
                             video.play();

--- a/sample_videostab.html
+++ b/sample_videostab.html
@@ -221,11 +221,16 @@
                     video.addEventListener('loadeddata', readyListener);
 
                     compatibility.getUserMedia({video: true}, function(stream) {
-                        try {
-                            video.src = compatibility.URL.createObjectURL(stream);
-                        } catch (error) {
-                            video.src = stream;
+                        if(video.srcObject !== undefined){
+                            video.srcObject = stream
+                        } else {
+                            try {
+                                video.src = compatibility.URL.createObjectURL(stream);
+                            } catch (error) {
+                                video.src = stream;
+                            }
                         }
+                        
                         setTimeout(function() {
                                 video.play();
                             }, 500);

--- a/sample_warp_affine.html
+++ b/sample_warp_affine.html
@@ -69,10 +69,14 @@
                 video.addEventListener('loadeddata', readyListener);
 
                 compatibility.getUserMedia({video: true}, function(stream) {
-                    try {
-                        video.src = compatibility.URL.createObjectURL(stream);
-                    } catch (error) {
-                        video.src = stream;
+                    if(video.srcObject !== undefined){
+                        video.srcObject = stream
+                    } else {
+                        try {
+                            video.src = compatibility.URL.createObjectURL(stream);
+                        } catch (error) {
+                            video.src = stream;
+                        }
                     }
                     setTimeout(function() {
                             video.play();

--- a/sample_warp_perspective.html
+++ b/sample_warp_perspective.html
@@ -69,10 +69,14 @@
                 video.addEventListener('loadeddata', readyListener);
 
                 compatibility.getUserMedia({video: true}, function(stream) {
-                    try {
-                        video.src = compatibility.URL.createObjectURL(stream);
-                    } catch (error) {
-                        video.src = stream;
+                    if(video.srcObject !== undefined){
+                        video.srcObject = stream
+                    } else {
+                        try {
+                            video.src = compatibility.URL.createObjectURL(stream);
+                        } catch (error) {
+                            video.src = stream;
+                        }
                     }
                     setTimeout(function() {
                             video.play();

--- a/sample_yape.html
+++ b/sample_yape.html
@@ -69,10 +69,14 @@
                 video.addEventListener('loadeddata', readyListener);
 
                 compatibility.getUserMedia({video: true}, function(stream) {
-                    try {
-                        video.src = compatibility.URL.createObjectURL(stream);
-                    } catch (error) {
-                        video.src = stream;
+                    if(video.srcObject !== undefined){
+                        video.srcObject = stream
+                    } else {
+                        try {
+                            video.src = compatibility.URL.createObjectURL(stream);
+                        } catch (error) {
+                            video.src = stream;
+                        }
                     }
                     setTimeout(function() {
                             video.play();

--- a/sample_yape06.html
+++ b/sample_yape06.html
@@ -70,10 +70,14 @@
                 video.addEventListener('loadeddata', readyListener);
 
                 compatibility.getUserMedia({video: true}, function(stream) {
-                    try {
-                        video.src = compatibility.URL.createObjectURL(stream);
-                    } catch (error) {
-                        video.src = stream;
+                    if(video.srcObject !== undefined){
+                        video.srcObject = stream
+                    } else {
+                        try {
+                            video.src = compatibility.URL.createObjectURL(stream);
+                        } catch (error) {
+                            video.src = stream;
+                        }
                     }
                     setTimeout(function() {
                             video.play();


### PR DESCRIPTION
The demos can not run in the latest browsers
as reference here:
![image](https://user-images.githubusercontent.com/40381396/83386316-6db7f280-a41d-11ea-8f91-c642db4d7183.png)
